### PR TITLE
80MHz Flash and DIO as default for generic ESP8266

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -569,15 +569,15 @@ generic.menu.CpuFrequency.80.build.f_cpu=80000000L
 generic.menu.CpuFrequency.160=160 MHz
 generic.menu.CpuFrequency.160.build.f_cpu=160000000L
 
-generic.menu.FlashFreq.40=40MHz
-generic.menu.FlashFreq.40.build.flash_freq=40
 generic.menu.FlashFreq.80=80MHz
 generic.menu.FlashFreq.80.build.flash_freq=80
+generic.menu.FlashFreq.40=40MHz
+generic.menu.FlashFreq.40.build.flash_freq=40
 
-generic.menu.FlashMode.qio=QIO
-generic.menu.FlashMode.qio.build.flash_mode=qio
 generic.menu.FlashMode.dio=DIO
 generic.menu.FlashMode.dio.build.flash_mode=dio
+generic.menu.FlashMode.qio=QIO
+generic.menu.FlashMode.qio.build.flash_mode=qio
 
 generic.menu.UploadSpeed.115200=115200
 generic.menu.UploadSpeed.115200.upload.speed=115200


### PR DESCRIPTION
DIO default because QIO makes problems when using GPIO 9 and 10
And 80MHz well because it's faster